### PR TITLE
Enable dev branch pages preview

### DIFF
--- a/.github/workflows/dev-pages.yml
+++ b/.github/workflows/dev-pages.yml
@@ -1,0 +1,39 @@
+name: Deploy dev preview
+
+on:
+  push:
+    branches:
+      - dev
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages-dev'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pandas astropy numpy jinja2 toml
+      - name: Build site
+        run: python make_rratalog.py
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: '.'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1
+        with:
+          preview: true

--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ This repository contains the published parameters of each RRAT in its own TOML f
 The RRATalog is maintained by Evan Lewis (efl0003 (at) mix.wvu.edu) and Maura McLaughlin (maura.mclaughlin (at) mail.wvu.edu). 
 We welcome additions, updates, and corrections to the RRATalog-- either in the form of GitHub pull requests (edit/add the TOML files and we'll take care of the rest), or you can email the maintainers.
 If you use the RRATalog, please acknowledge the URL above, and cite Agarwal et al. (in prep).  
+
+## Development preview
+
+Changes pushed to the `dev` branch are automatically deployed to a temporary GitHub Pages preview using the workflow in `.github/workflows/dev-pages.yml`. Each preview build runs `make_rratalog.py` and publishes the generated site using the `actions/deploy-pages` action. The preview URL is provided in the workflow run summary and expires automatically after a few days.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy dev branch changes as a Pages preview
- document the workflow in the README

## Testing
- `python make_rratalog.py` (after installing deps)


------
https://chatgpt.com/codex/tasks/task_b_685588f44b308331a1dfa42a53d9c371