### PR TITLE
Add requirements and install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,13 @@ This repository contains the published parameters of each RRAT in its own TOML f
 The RRATalog is maintained by Evan Lewis (efl0003 (at) mix.wvu.edu) and Maura McLaughlin (maura.mclaughlin (at) mail.wvu.edu). 
 We welcome additions, updates, and corrections to the RRATalog-- either in the form of GitHub pull requests (edit/add the TOML files and we'll take care of the rest), or you can email the maintainers.
 If you use the RRATalog, please acknowledge the URL above, and cite Agarwal et al. (in prep).  
+
+## Installation
+
+To install the dependencies required to build and work with the RRATalog, run:
+
+```
+pip install -r requirements.txt
+```
+
+This installs packages such as `toml`, `pandas`, `jinja2`, `numpy`, and `astropy`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+toml
+pandas
+jinja2
+numpy
+astropy


### PR DESCRIPTION
## Summary
- add requirements.txt for Python dependencies
- document how to install the dependencies

## Testing
- `python -m py_compile make_rratalog.py`


------
https://chatgpt.com/codex/tasks/task_b_68558413a01883318119b3563b95a8fd