### PR TITLE
Allow specifying directory for .toml files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,19 @@ The web version of the RRATalog is located at https://rratalog.github.io/rratalo
 The RRATalog is a comprehensive catalog of radio pulsars categorized as Rotating Radio Transients (RRATs). 
 For clarity, we only include published pulsars which were discovered through their single pulses rather than a periodicity search.
 
-This repository contains the published parameters of each RRAT in its own TOML file, located in the "rrats" directory. We also provide a machine-readable CSV version of the RRATalog. 
+This repository contains the published parameters of each RRAT in its own TOML file, located in the "rrats" directory. We also provide a machine-readable CSV version of the RRATalog.
+
+## Generating the catalog
+
+The script `make_rratalog.py` reads the individual TOML files and creates the
+CSV and HTML versions of the catalog. Run it from the repository root with:
+
+```bash
+python make_rratalog.py --data-dir ./rrats
+```
+
+Omitting `--data-dir` defaults to `./rrats`, so the command above works
+out-of-the-box.
 
 The RRATalog is maintained by Evan Lewis (efl0003 (at) mix.wvu.edu) and Maura McLaughlin (maura.mclaughlin (at) mail.wvu.edu). 
 We welcome additions, updates, and corrections to the RRATalog-- either in the form of GitHub pull requests (edit/add the TOML files and we'll take care of the rest), or you can email the maintainers.

--- a/make_rratalog.py
+++ b/make_rratalog.py
@@ -4,6 +4,8 @@ from pprint import pprint as print
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 import numpy as np
+import argparse
+import os
 
 make_html = True #if True, will save rratalog.html
 make_csv = True #if True, will save rratalog.csv
@@ -111,7 +113,16 @@ for i in range(len(table_keys)):
         unit_keys.append(table_keys[i])
 
 if __name__ == "__main__":
-    list_of_rrats = glob.glob("J*.toml")
+    parser = argparse.ArgumentParser(description="Generate RRATalog outputs")
+    parser.add_argument(
+        "--data-dir",
+        default="./rrats",
+        help="Directory containing .toml files",
+    )
+    args = parser.parse_args()
+
+    data_dir = args.data_dir
+    list_of_rrats = glob.glob(os.path.join(data_dir, "J*.toml"))
     list_of_rrats.sort()
     display_dict = {}
     rrat_dict = {}


### PR DESCRIPTION
## Summary
- accept optional `--data-dir` argument in `make_rratalog.py`
- document running `make_rratalog.py` in `README`

## Testing
- `python make_rratalog.py --help`
- `python make_rratalog.py --data-dir ../rrats` *(fails: TemplateNotFound)*

------
https://chatgpt.com/codex/tasks/task_b_6855841012b08331a7ff1a65c224031a