### PR TITLE
Fix template path and FAST field

### DIFF
--- a/make_rratalog.py
+++ b/make_rratalog.py
@@ -389,7 +389,7 @@ if __name__ == "__main__":
 
     if make_html==True:
         display_df = full_display_df.drop(full_display_df.iloc[:,17:],axis=1)
-        templateLoader = jinja2.FileSystemLoader(searchpath='./')
+        templateLoader = jinja2.FileSystemLoader(searchpath=os.path.join(os.path.dirname(__file__), 'templates'))
         env = jinja2.Environment(loader=templateLoader,trim_blocks=True,lstrip_blocks=True)
         template = env.get_template('template.html')
         with open("rratalog.html", "w") as fh:

--- a/rrats/J1918-0449.toml
+++ b/rrats/J1918-0449.toml
@@ -49,7 +49,7 @@ ref = "https://doi.org/10.48550/arXiv.2206.03091"
   value= 54.5 #hour^-1
   error= false
   frequency= 1250 #MHz
-  telescope= FAST
+  telescope = "FAST"
   minflux= 54.13 #mJy
   ref = "https://doi.org/10.48550/arXiv.2206.03091"
   #Average burst rate-- 1 burst every 66 seconds


### PR DESCRIPTION
## Summary
- add quotes around FAST telescope entry in J1918-0449 TOML so it parses
- correct template path in `make_rratalog.py` so HTML generation works

## Testing
- `pip install -r requirements.txt`
- `python make_rratalog.py --data-dir ./rrats`

------
https://chatgpt.com/codex/tasks/task_b_6855a5175a20833188ffee39db5a5217